### PR TITLE
Refactor wait(::Session) so that the polling happens asynchronously

### DIFF
--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -30,6 +30,11 @@ Changelog](https://keepachangelog.com).
 - Fixed a race condition in the [`Demo.DemoServer`](@ref) that could cause
   segfaults ([#16]).
 
+### Changed
+
+- **Breaking**: [`Session`](@ref) now needs to be closed explictly instead of
+  relying on the finalizer for the memory to be freed.
+
 ## [v0.5.0] - 2024-08-10
 
 ### Added

--- a/src/LibSSH.jl
+++ b/src/LibSSH.jl
@@ -163,18 +163,15 @@ end
 # poll_fd() in a try-catch in case the bind (and thus the file descriptor) has
 # been closed in the meantime, which would cause poll_fd() to throw an IOError:
 # https://github.com/JuliaLang/julia/pull/52377.
-#
-# Note: the whole polling design is bad. We should only have one task polling
-# the session and waking up other listeners.
 function _safe_poll_fd(args...; kwargs...)
     result = nothing
-    # try
+    try
         result = FileWatching.poll_fd(args...; kwargs...)
-    # catch ex
-    #     if !(ex isa Base.IOError)
-    #         rethrow()
-    #     end
-    # end
+    catch ex
+        if !(ex isa Base.IOError) && !(ex isa TypeError)
+            rethrow()
+        end
+    end
 
     return result
 end

--- a/src/channel.jl
+++ b/src/channel.jl
@@ -636,6 +636,7 @@ function Base.run(cmd::Cmd, session::Session;
     set_channel_callbacks(process._sshchan, callbacks)
 
     process._task = Threads.@spawn _exec_command(process)
+    errormonitor(process._task)
     if wait
         # Note the use of Base.wait() to avoid aliasing with the `wait` argument
         Base.wait(process._task)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -12,3 +12,30 @@ function _socketpair()
 
     return sock1, sock2
 end
+
+
+# Helper type to allow closing a Threads.Condition
+mutable struct CloseableCondition
+    @atomic closed::Bool
+    cond::Threads.Condition
+
+    CloseableCondition() = new(false, Threads.Condition())
+end
+
+function Base.wait(cond::CloseableCondition)
+    if @atomic cond.closed
+        throw(InvalidStateException("Condition has been closed", :closed))
+    end
+
+    wait(cond.cond)
+end
+
+function Base.close(cond::CloseableCondition)
+    @atomic cond.closed = true
+    notify(cond, InvalidStateException("Condition is closed", :closed); error=true)
+    return nothing
+end
+
+Base.notify(cond::CloseableCondition, args...; kwargs...) = notify(cond.cond, args...; kwargs...)
+Base.lock(cond::CloseableCondition) = lock(cond.cond)
+Base.unlock(cond::CloseableCondition) = unlock(cond.cond)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -23,7 +23,7 @@ mutable struct CloseableCondition
 end
 
 function Base.wait(cond::CloseableCondition)
-    if @atomic cond.closed
+    if !isopen(cond)
         throw(InvalidStateException("Condition has been closed", :closed))
     end
 
@@ -39,3 +39,4 @@ end
 Base.notify(cond::CloseableCondition, args...; kwargs...) = notify(cond.cond, args...; kwargs...)
 Base.lock(cond::CloseableCondition) = lock(cond.cond)
 Base.unlock(cond::CloseableCondition) = unlock(cond.cond)
+Base.isopen(cond::CloseableCondition) = !(@atomic cond.closed)


### PR DESCRIPTION
Previously each call to `wait(::Session)` would poll the sessions file descriptor individually. This is kinda not great because one caller may be woken up for some data that's intended for another caller. In practice this hasn't caused problems so far because most of LibSSH's usage has been in the tests where we do a single operation at a time, but the new architecture should be safer.

Now there's a separate waiter task that lives for as long as the session that can be woken up by callers wanting to wait() on the session, who will in turn be woken up whenever the waiter tasks polls the session file descriptor successfully. i.e. it turns the waiting from a 1-to-1 thing to a 1-to-many thing.